### PR TITLE
Add progress bars and uniform image size option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ CLI for conversions and merging, or import functions in notebooks.
 - COCO -> YOLO: Write YOLO .txt labels and `classes.txt` from COCO
 - Merge COCO: Merge multiple COCO datasets with id remapping and options
 - Optional Pillow for image size detection; or provide a sizes CSV
+- Progress bars for conversions (CLI and notebooks) using `tqdm`
 
 ## Installation
 Install from PyPI for the CLI and library:
@@ -40,6 +41,7 @@ Subcommands
     --labels ./labels \
     --classes ./classes.txt \    # optional
     --sizes ./sizes.csv \        # optional; overrides Pillow sizes
+    --image-size 1920 1080 \     # optional; skip per-image size reads
     --bbox-round 2 \             # decimals for bbox/area (use <0 to disable)
     --file-name-mode name \      # name | relative
     --out ./coco.json
@@ -79,6 +81,7 @@ coco = yolo_to_coco(
     labels_dir=Path("./labels"),
     classes_path=Path("./classes.txt"),  # or None
     sizes_csv=None,  # or Path("./sizes.csv")
+    image_size=(1920, 1080),  # optional uniform size
 )
 with open("coco.json", "w", encoding="utf-8") as f:
     json.dump(coco, f, ensure_ascii=False, indent=2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.9"
 keywords = ["yolo", "coco", "detection", "dataset", "conversion", "merge", "annotation"]
 dependencies = [
   "Pillow>=9.0",
+  "tqdm>=4.64",
 ]
 license = { file = "LICENSE" }
 classifiers = [

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -91,3 +91,17 @@ def test_yolo_to_coco_and_visualize(images_dir: Path, labels_dir: Path, sample_i
 
     # Save original too for comparison
     img.save(artifacts_dir / "sample_original.jpg", quality=95)
+
+
+def test_yolo_to_coco_with_uniform_size(monkeypatch, images_dir: Path, labels_dir: Path, sample_image: Path):
+    from PIL import Image
+
+    with Image.open(sample_image) as im:
+        size = (im.width, im.height)
+
+    def fail_open(*args, **kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("Image.open should not be called when image_size is provided")
+
+    monkeypatch.setattr("PIL.Image.open", fail_open)
+    coco = yolo_to_coco(images_dir, labels_dir, image_size=size, show_progress=False)
+    assert any(img["width"] == size[0] and img["height"] == size[1] for img in coco["images"])

--- a/yolococo/cli.py
+++ b/yolococo/cli.py
@@ -35,6 +35,14 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="CSV: filename,width,height (optional if Pillow installed)",
     )
+    s1.add_argument(
+        "--image-size",
+        type=int,
+        nargs=2,
+        metavar=("WIDTH", "HEIGHT"),
+        default=None,
+        help="If all images share the same size, specify WIDTH HEIGHT to skip reading image files",
+    )
     s1.add_argument("--out", type=Path, required=True, help="Output COCO JSON path")
     s1.add_argument(
         "--bbox-round",
@@ -118,6 +126,7 @@ def main(args: Sequence[str] | None = None) -> None:
                 ns.sizes,
                 bbox_round=ns.bbox_round,
                 file_name_mode=ns.file_name_mode,
+                image_size=tuple(ns.image_size) if ns.image_size else None,
             )
             ns.out.parent.mkdir(parents=True, exist_ok=True)
             with ns.out.open("w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- show tqdm-based progress bars for YOLO↔COCO conversions
- allow supplying a uniform image size to skip reading image files
- document new CLI flag and programmatic parameter

## Testing
- `pip install -e .[test]` *(failed: Could not find a version that satisfies the requirement setuptools>=61.0)*
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9608660988326a40f83d359067c3b