### PR TITLE
Include supercategory field in COCO output

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ CLI for conversions and merging, or import functions in notebooks.
 
 ## Features
 - YOLO -> COCO: Build COCO JSON from YOLO labels and image sizes
+- Categories in COCO output now include a `supercategory` field (defaults to the class name)
 - COCO -> YOLO: Write YOLO .txt labels and `classes.txt` from COCO
 - Merge COCO: Merge multiple COCO datasets with id remapping and options
 - Optional Pillow for image size detection; or provide a sizes CSV

--- a/coco_merge/merger.py
+++ b/coco_merge/merger.py
@@ -117,10 +117,13 @@ def merge_datasets(
             cat_map = {int(c["id"]): int(c["id"]) for c in cats}
         cat_maps.append(cat_map)
 
-    merged_categories = sorted(
-        [{"id": int(c["id"]), "name": c.get("name", "")} for c in first_cats],
-        key=lambda c: c["id"],
-    )
+    def _copy_cat(c: dict) -> dict:
+        new_c = {"id": int(c["id"]), "name": c.get("name", "")}
+        if "supercategory" in c:
+            new_c["supercategory"] = c.get("supercategory", "")
+        return new_c
+
+    merged_categories = sorted([_copy_cat(c) for c in first_cats], key=lambda c: c["id"])
 
     # Licenses: collect, dedup, and build mapping per dataset
     all_licenses = []

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -47,6 +47,8 @@ def test_yolo_to_coco_and_visualize(images_dir: Path, labels_dir: Path, sample_i
     # Basic sanity checks
     assert "images" in coco and "annotations" in coco and "categories" in coco
     assert any(img["file_name"] == sample_image.name for img in coco["images"])  # image present
+    assert all("supercategory" in c for c in coco["categories"])  # categories have supercategory
+    assert all(c["supercategory"] == c["name"] for c in coco["categories"])  # default value
 
     # Save COCO JSON artifact for manual inspection
     (artifacts_dir / "coco.json").write_text(json.dumps(coco, ensure_ascii=False, indent=2), encoding="utf-8")

--- a/yolococo/convert.py
+++ b/yolococo/convert.py
@@ -136,7 +136,7 @@ def yolo_to_coco(
     # Build categories (if classes known now)
     if classes:
         for i, name in enumerate(classes):
-            categories.append({"id": i, "name": name})
+            categories.append({"id": i, "name": name, "supercategory": name})
 
     img_files = sorted([p for p in images_dir.rglob("*") if p.suffix.lower() in IMAGE_EXTS])
     if not img_files:
@@ -230,7 +230,14 @@ def yolo_to_coco(
     # If classes.txt was missing, synthesize categories from seen ids
     if not categories:
         categories = (
-            [{"id": cid, "name": f"class_{cid}"} for cid in sorted(seen_class_ids)]
+            [
+                {
+                    "id": cid,
+                    "name": f"class_{cid}",
+                    "supercategory": f"class_{cid}",
+                }
+                for cid in sorted(seen_class_ids)
+            ]
             if seen_class_ids
             else []
         )


### PR DESCRIPTION
## Summary
- Add `supercategory` to COCO categories when converting from YOLO
- Preserve `supercategory` when merging COCO datasets
- Document new `supercategory` behavior and test for it

## Testing
- `pip install -e .[test]` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yolococo')*

------
https://chatgpt.com/codex/tasks/task_e_68b96ff355188326a9a1f45471e4b7fe