### PR TITLE
feat: allow user-supplied info and supercategory

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ CLI for conversions and merging, or import functions in notebooks.
 
 ## Features
 - YOLO -> COCO: Build COCO JSON from YOLO labels and image sizes
-- Categories in COCO output now include a `supercategory` field (defaults to the class name)
+- Categories in COCO output include a `supercategory` field (defaults to the class name or a user override)
+- Optional COCO `info` metadata in outputs
 - COCO -> YOLO: Write YOLO .txt labels and `classes.txt` from COCO
 - Merge COCO: Merge multiple COCO datasets with id remapping and options
 - Optional Pillow for image size detection; or provide a sizes CSV
@@ -45,6 +46,8 @@ Subcommands
     --image-size 1920 1080 \     # optional; skip per-image size reads
     --bbox-round 2 \             # decimals for bbox/area (use <0 to disable)
     --file-name-mode name \      # name | relative
+    --info '{"description":"my dataset"}' \  # optional COCO info
+    --supercategory object \      # optional: set all supercategories
     --out ./coco.json
   ```
   sizes.csv format (no header): `filename,width,height`.
@@ -83,6 +86,8 @@ coco = yolo_to_coco(
     classes_path=Path("./classes.txt"),  # or None
     sizes_csv=None,  # or Path("./sizes.csv")
     image_size=(1920, 1080),  # optional uniform size
+    info={"description": "my dataset"},  # optional COCO info
+    supercategory="object",  # optional: set all supercategories
 )
 with open("coco.json", "w", encoding="utf-8") as f:
     json.dump(coco, f, ensure_ascii=False, indent=2)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -107,3 +107,17 @@ def test_yolo_to_coco_with_uniform_size(monkeypatch, images_dir: Path, labels_di
     monkeypatch.setattr("PIL.Image.open", fail_open)
     coco = yolo_to_coco(images_dir, labels_dir, image_size=size, show_progress=False)
     assert any(img["width"] == size[0] and img["height"] == size[1] for img in coco["images"])
+
+
+def test_yolo_to_coco_info_and_supercategory(images_dir: Path, labels_dir: Path):
+    info = {"description": "test dataset"}
+    sc = "thing"
+    coco = yolo_to_coco(
+        images_dir,
+        labels_dir,
+        info=info,
+        supercategory=sc,
+        show_progress=False,
+    )
+    assert coco["info"] == info
+    assert all(c["supercategory"] == sc for c in coco["categories"])

--- a/yolococo/cli.py
+++ b/yolococo/cli.py
@@ -56,6 +56,16 @@ def build_parser() -> argparse.ArgumentParser:
         default="name",
         help="COCO image file_name mode: basename or path relative to --images",
     )
+    s1.add_argument(
+        "--info",
+        default=None,
+        help="JSON string or path to JSON file for COCO 'info' field",
+    )
+    s1.add_argument(
+        "--supercategory",
+        default=None,
+        help="If set, use this string for all category supercategories",
+    )
 
     # coco2yolo
     s2 = sub.add_parser("coco2yolo", help="Convert COCO JSON to YOLO txt labels")
@@ -119,6 +129,14 @@ def main(args: Sequence[str] | None = None) -> None:
 
     try:
         if ns.cmd == "yolo2coco":
+            info_obj = None
+            if ns.info:
+                info_candidate = Path(ns.info)
+                if info_candidate.exists():
+                    with info_candidate.open("r", encoding="utf-8") as f:
+                        info_obj = json.load(f)
+                else:
+                    info_obj = json.loads(ns.info)
             coco = yolo_to_coco(
                 ns.images,
                 ns.labels,
@@ -127,6 +145,8 @@ def main(args: Sequence[str] | None = None) -> None:
                 bbox_round=ns.bbox_round,
                 file_name_mode=ns.file_name_mode,
                 image_size=tuple(ns.image_size) if ns.image_size else None,
+                info=info_obj,
+                supercategory=ns.supercategory,
             )
             ns.out.parent.mkdir(parents=True, exist_ok=True)
             with ns.out.open("w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- allow passing a top-level `info` dict to `yolo_to_coco`
- add option to fix all category `supercategory` values from CLI or API
- document new options and test handling of `info`/`supercategory`

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b97e235ca883269d006c0d84ee5aae